### PR TITLE
Improve document preview fidelity and version handling

### DIFF
--- a/frontend/src/types/mammoth-browser.d.ts
+++ b/frontend/src/types/mammoth-browser.d.ts
@@ -1,0 +1,23 @@
+declare module 'mammoth/mammoth.browser' {
+  interface ConvertToHtmlOptions {
+    arrayBuffer: ArrayBuffer
+  }
+
+  interface MammothMessage {
+    type: string
+    message: string
+  }
+
+  interface ConvertToHtmlResult {
+    value: string
+    messages: MammothMessage[]
+  }
+
+  export function convertToHtml(options: ConvertToHtmlOptions): Promise<ConvertToHtmlResult>
+
+  const mammoth: {
+    convertToHtml: typeof convertToHtml
+  }
+
+  export default mammoth
+}


### PR DESCRIPTION
## Summary
- enhance the document previewer with DOCX-to-HTML rendering and more resilient PDF embedding
- highlight the most recent version in the editor and sort previous versions chronologically
- keep edited documents at the top of the list by sorting responses by update timestamp and add type definitions for Mammoth

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e62f3285308333aa266ab74ec5f299