### PR TITLE
Handle missing OnlyOffice configuration gracefully

### DIFF
--- a/backend/documents.py
+++ b/backend/documents.py
@@ -697,6 +697,7 @@ async def get_document_content(
         content=content,
         supports_editing=supports_editing,
         can_edit=can_edit,
+        supports_onlyoffice=use_onlyoffice,
         message=message
     )
 
@@ -805,6 +806,7 @@ async def update_document_content(
         content=payload.content,
         supports_editing=True,
         can_edit=True,
+        supports_onlyoffice=False,
         message="Document content updated successfully"
     )
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -338,6 +338,7 @@ class DocumentContentResponse(BaseModel):
     content: str
     supports_editing: bool
     can_edit: bool
+    supports_onlyoffice: bool = False
     message: Optional[str] = None
 
 


### PR DESCRIPTION
## Summary
- add a supports_onlyoffice flag to the document content API response so the frontend knows when the embedded editor is available
- update the OnlyOffice session flow to rely on the backend flag, preventing edit attempts when the document server is not configured

## Testing
- npm run lint *(fails: Missing script: "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68e665f7b0488333a97d04a841a5e602